### PR TITLE
Spring week5

### DIFF
--- a/spring_week04/querydsl/querydsl/build.gradle
+++ b/spring_week04/querydsl/querydsl/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 
 tasks.named('test') {

--- a/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/Board.java
+++ b/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/Board.java
@@ -1,0 +1,51 @@
+package study.querydsl.entity;
+
+import jakarta.persistence.*;
+import lombok.Setter;
+
+@Entity
+public class Board {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    // Board(게시글)와 User(작성자)는 다대일 관계
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User writer;  // 이 부분이 User 엔티티의 boards 필드와 연결되는 속성입니다.
+
+    // 기본 생성자
+    public Board() {
+    }
+
+    public Board(String title, String content, User writer) {
+        this.title = title;
+        this.content = content;
+        this.writer = writer;
+    }
+
+    // Getter 및 Setter
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public User getWriter() {
+        return writer;
+    }
+
+}

--- a/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/Board.java
+++ b/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/Board.java
@@ -21,7 +21,6 @@ public class Board {
     @JoinColumn(name = "user_id")
     private User writer;  // 이 부분이 User 엔티티의 boards 필드와 연결되는 속성입니다.
 
-    // 기본 생성자
     public Board() {
     }
 
@@ -31,7 +30,6 @@ public class Board {
         this.writer = writer;
     }
 
-    // Getter 및 Setter
     public Long getId() {
         return id;
     }

--- a/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/Comment.java
+++ b/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/Comment.java
@@ -1,0 +1,45 @@
+package study.querydsl.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    // Comment(댓글)와 Board(게시글)는 다대일 관계
+    @ManyToOne
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    // 기본 생성자
+    public Comment() {}
+
+    // 생성자
+    public Comment(String content, Board board) {
+        this.content = content;
+        this.board = board;
+    }
+
+    // Getter 및 Setter
+    public Long getId() {
+        return id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Board getBoard() {
+        return board;
+    }
+
+    public void setBoard(Board board) {
+        this.board = board;
+    }
+}
+

--- a/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/Comment.java
+++ b/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/Comment.java
@@ -16,16 +16,13 @@ public class Comment {
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
-    // 기본 생성자
     public Comment() {}
 
-    // 생성자
     public Comment(String content, Board board) {
         this.content = content;
         this.board = board;
     }
 
-    // Getter 및 Setter
     public Long getId() {
         return id;
     }

--- a/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/User.java
+++ b/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/User.java
@@ -1,0 +1,45 @@
+package study.querydsl.entity;
+
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    // User(작성자)와 Board(게시글)는 1대다 관계
+    @OneToMany(mappedBy = "writer")
+    private List<Board> boards = new ArrayList<>();
+
+    // 기본 생성자
+    public User() {}
+
+    public User(String name) {
+        this.name = name;
+    }
+
+    // Getter 및 Setter
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Board> getBoards() {
+        return boards;
+    }
+
+    public void addBoard(Board board) {
+        boards.add(board);
+    }
+}

--- a/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/User.java
+++ b/spring_week04/querydsl/querydsl/src/main/java/study/querydsl/entity/User.java
@@ -15,18 +15,16 @@ public class User {
     @Column(nullable = false)
     private String name;
 
-    // User(작성자)와 Board(게시글)는 1대다 관계
+    // User(작성자)와 Board(게시글)는 일대다 관계
     @OneToMany(mappedBy = "writer")
     private List<Board> boards = new ArrayList<>();
 
-    // 기본 생성자
     public User() {}
 
     public User(String name) {
         this.name = name;
     }
 
-    // Getter 및 Setter
     public Long getId() {
         return id;
     }

--- a/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/BoardRepository.java
+++ b/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/BoardRepository.java
@@ -1,0 +1,9 @@
+package study.querydsl.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import study.querydsl.entity.Board;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+    // 추가적으로 커스텀 메서드가 필요하다면 여기에 작성
+}
+

--- a/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/BoardRepositoryTest.java
+++ b/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/BoardRepositoryTest.java
@@ -1,0 +1,64 @@
+package study.querydsl.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import study.querydsl.entity.Board;
+import study.querydsl.entity.User;
+import study.querydsl.entity.Comment;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+public class BoardRepositoryTest {
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Test
+    void saveAndFindBoardWithCommentsTest() {
+        // 작성자 생성
+        User user = new User("지");
+        userRepository.save(user);
+
+        // 게시글 생성 및 저장
+        Board board1 = new Board("제목 1", "내용 1", user);
+        Board board2 = new Board("제목 2", "내용 2", user);
+        boardRepository.save(board1);
+        boardRepository.save(board2);
+
+        // 댓글 생성 및 저장
+        Comment comment1 = new Comment("댓글 추가", board1);
+        Comment comment2 = new Comment("멋사 스프링 5주차 과제중", board1);
+        Comment comment3 = new Comment("잘 실행되고 있는거니?! 앙?!", board2);
+        commentRepository.save(comment1);
+        commentRepository.save(comment2);
+        commentRepository.save(comment3);
+
+        // 저장된 게시글 조회
+        List<Board> boards = boardRepository.findAll();
+        assertNotNull(boards);
+        assertFalse(boards.isEmpty());
+
+        // 출력: 조회한 게시글 정보 및 댓글 정보 출력
+        boards.forEach(board -> {
+            System.out.println("제목: " + board.getTitle() + " - 작성자: " + board.getWriter().getName());
+
+            // 게시글에 달린 댓글 출력
+            List<Comment> comments = commentRepository.findByBoard(board);
+            comments.forEach(comment ->
+                    System.out.println("   댓글: " + comment.getContent()));
+        });
+    }
+}
+
+

--- a/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/CommentRepository.java
+++ b/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package study.querydsl.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import study.querydsl.entity.Board;
+import study.querydsl.entity.Comment;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByBoard(Board board);
+}

--- a/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/ProductRepositoryTest.java
+++ b/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/ProductRepositoryTest.java
@@ -1,79 +1,79 @@
-package study.querydsl.repository;
-
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import study.querydsl.entity.Product;
-import study.querydsl.entity.QProduct;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-@DataJpaTest
-@Transactional
-class ProductRepositoryTest {
-
-    @Autowired
-    private ProductRepository productRepository;
-
-    @Autowired
-    EntityManager entityManager;
-
-    @BeforeEach
-    void setUp() {
-        // 테스트 데이터를 저장하는 코드
-        productRepository.save(new Product("펜", 1000, 100, 500));
-        productRepository.save(new Product("연필", 500, 200, 400));
-        productRepository.save(new Product("노트", 2000, 150, 900));
-        productRepository.save(new Product("지우개", 300, 300, 300));
-        productRepository.save(new Product("자", 700, 250, 450));
-    }
-
-    @Test
-    void queryDslTest() {
-        JPAQueryFactory query = new JPAQueryFactory(entityManager);
-        QProduct qProduct = QProduct.product;
-
-        List<Product> productList =
-                query.selectFrom(qProduct)
-                        .where(qProduct.name.eq("펜"))
-                        .orderBy(qProduct.price.asc())
-                        .fetch();
-
-        for(Product product : productList) {
-            System.out.println("-----------------------");
-            System.out.println("Product Number : " + product.getId());
-            System.out.println("Product Name : " + product.getName());
-            System.out.println("Product Price : " + product.getPrice());
-            System.out.println("Product Stock : " + product.getStock());
-            System.out.println("-----------------------");
-        }
-    }
-
-    @Test
-    void findTop10ByPopularityTest() {
-        List<Product> topPopularProducts = productRepository.findTop10ByPopularity();
-        assertNotNull(topPopularProducts);
-        assertFalse(topPopularProducts.isEmpty());
-        assertTrue(topPopularProducts.size() <= 10);
-
-        topPopularProducts.forEach(product ->
-                System.out.println(product.getName() + " - Popularity: " + product.getPopularity()));
-    }
-
-    @Test
-    void findTop10ByRecentTest() {
-        List<Product> recentProducts = productRepository.findTop10ByRecent();
-        assertNotNull(recentProducts);
-        assertFalse(recentProducts.isEmpty());
-        assertTrue(recentProducts.size() <= 10);
-
-        recentProducts.forEach(product ->
-                System.out.println(product.getName() + " - ID: " + product.getId()));
-    }
-}
+//package study.querydsl.repository;
+//
+//import com.querydsl.jpa.impl.JPAQueryFactory;
+//import jakarta.persistence.EntityManager;
+//import jakarta.transaction.Transactional;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+//import study.querydsl.entity.Product;
+//import study.querydsl.entity.QProduct;
+//
+//import java.util.List;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//@DataJpaTest
+//@Transactional
+//class ProductRepositoryTest {
+//
+//    @Autowired
+//    private ProductRepository productRepository;
+//
+//    @Autowired
+//    EntityManager entityManager;
+//
+//    @BeforeEach
+//    void setUp() {
+//        // 테스트 데이터를 저장하는 코드
+//        productRepository.save(new Product("펜", 1000, 100, 500));
+//        productRepository.save(new Product("연필", 500, 200, 400));
+//        productRepository.save(new Product("노트", 2000, 150, 900));
+//        productRepository.save(new Product("지우개", 300, 300, 300));
+//        productRepository.save(new Product("자", 700, 250, 450));
+//    }
+//
+//    @Test
+//    void queryDslTest() {
+//        JPAQueryFactory query = new JPAQueryFactory(entityManager);
+//        QProduct qProduct = QProduct.product;
+//
+//        List<Product> productList =
+//                query.selectFrom(qProduct)
+//                        .where(qProduct.name.eq("펜"))
+//                        .orderBy(qProduct.price.asc())
+//                        .fetch();
+//
+//        for(Product product : productList) {
+//            System.out.println("-----------------------");
+//            System.out.println("Product Number : " + product.getId());
+//            System.out.println("Product Name : " + product.getName());
+//            System.out.println("Product Price : " + product.getPrice());
+//            System.out.println("Product Stock : " + product.getStock());
+//            System.out.println("-----------------------");
+//        }
+//    }
+//
+//    @Test
+//    void findTop10ByPopularityTest() {
+//        List<Product> topPopularProducts = productRepository.findTop10ByPopularity();
+//        assertNotNull(topPopularProducts);
+//        assertFalse(topPopularProducts.isEmpty());
+//        assertTrue(topPopularProducts.size() <= 10);
+//
+//        topPopularProducts.forEach(product ->
+//                System.out.println(product.getName() + " - Popularity: " + product.getPopularity()));
+//    }
+//
+//    @Test
+//    void findTop10ByRecentTest() {
+//        List<Product> recentProducts = productRepository.findTop10ByRecent();
+//        assertNotNull(recentProducts);
+//        assertFalse(recentProducts.isEmpty());
+//        assertTrue(recentProducts.size() <= 10);
+//
+//        recentProducts.forEach(product ->
+//                System.out.println(product.getName() + " - ID: " + product.getId()));
+//    }
+//}

--- a/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/UserRepository.java
+++ b/spring_week04/querydsl/querydsl/src/test/java/study/querydsl/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package study.querydsl.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import study.querydsl.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #39 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
[ 게시판, 작성자, 댓글 엔티티의 매핑 직접 구현해보기 ]
1. User (작성자) 엔티티
: User 클래스는 데이터베이스의 "users" 테이블과 매핑되는 사용자 엔티티
- User와 Board는 일대다 관계를 가지며, 하나의 User는 여러 개의 게시글을 작성할 수 있다.
- 게시글 리스트는 boards 필드로 관리되며, 새로운 게시글을 추가할 수 있는 메서드를 제공한다.
- JPA 매핑을 통해 각 사용자는 여러 게시글과 연결되며, 이 관계는 양방향 연관 관계로 설정되어 있다 (Board 클래스에서도 User와의 연관 관계가 정의됨).
 @Table(name = "users"): 이 어노테이션은 이 엔티티가 매핑될 테이블의 이름을 지정한다. 이 경우 users라는 이름의 테이블과 연결된다. 기본적으로 클래스명과 같은 이름으로 테이블이 생성되지만, Table 어노테이션을 통해 명시적으로 테이블 이름을 설정할 수 있다.
@OneToMany(mappedBy = "writer"): boards 필드는 Board 엔티티와의 일대다 관계를 나타낸다. 즉, 하나의 User가 여러 개의 Board(게시글)를 가질 수 있다는 의미이다. mappedBy = "writer"는 Board 엔티티의 writer 필드에 의해 연관 관계가 매핑되었음을 나타낸다. User 엔티티는 Board 엔티티의 작성자 역할을 하며, 여러 개의 게시글이 하나의 사용자에 연결된다.

2. Board (게시글) 엔티티
: JPA를 사용해 데이터베이스의 게시글(Board)과 사용자(User) 테이블을 다대일 관계로 매핑하는 엔티티 클래스
- 게시글은 반드시 제목과 내용을 포함해야 하고, 여러 게시글이 하나의 사용자와 연관될 수 있다.
@ManyToOne: writer 필드는 User 엔티티와 다대일 관계를 나타낸다. 즉, 여러 개의 Board 엔티티가 하나의 User 엔티티에 연결될 수 있다. 이는 여러 게시글이 하나의 작성자(User)와 연관될 수 있다는 것을 의미한다.
@JoinColumn(name = "user_id"): 이 어노테이션은 외래 키 컬럼을 지정한다. user_id라는 이름의 컬럼이 생성되며, 이는 게시글 작성자인 User 엔티티와 연관된 외래 키가 된다. Board 엔티티가 어떤 User와 연결되어 있는지 이 user_id 컬럼을 통해 데이터베이스에서 관리된다.

3. Comment (댓글) 엔티티
: Comment 클래스는 데이터베이스의 댓글 테이블과 매핑되는 엔티티로, 댓글의 내용을 저장하고, 댓글이 달린 게시글과의 관계를 정의한다.
- 댓글은 반드시 특정 게시글에 속해야 하며, 이를 위해 board_id라는 외래 키를 사용하여 Board 엔티티와 다대일 관계를 가진다.
- 댓글의 내용과 관련된 게시글을 쉽게 설정하고 관리할 수 있는 생성자와 메서드를 제공한다.
@ManyToOne: board 필드는 댓글(Comment)과 게시글(Board) 간의 다대일 관계를 나타낸다. 여러 댓글이 하나의 게시글에 연결될 수 있다. 즉, 하나의 게시글에 여러 개의 댓글이 달릴 수 있으며, 댓글은 하나의 게시글과만 연관된다.
@JoinColumn(name = "board_id", nullable = false): 이 어노테이션은 댓글이 연관된 게시글(Board)과의 외래 키를 설정한다. board_id라는 이름의 컬럼을 사용하여 댓글이 어느 게시글에 속해 있는지를 지정한다. 또한, nullable = false로 설정되어 있어 댓글은 반드시 게시글과 연관되어 있어야 한다. 즉, 댓글은 항상 특정 게시글에 속해야 하며, 게시글 없이 댓글을 생성할 수 없다.

4. BoardRepositoryTest
- 게시글(Board), 작성자(User), 그리고 댓글(Comment) 간의 연관 관계를 테스트하는 JUnit 테스트
- 작성자(User)는 여러 게시글(Board)을 가질 수 있으며, 각 게시글은 여러 댓글(Comment)을 가질 수 있다.
- > [ CommentRepository ]
: 댓글 조회 메서드 - commentRepository.findByBoard(board)라는 메서드는 테스트 코드에서 사용되고 있는데, 이 메서드가 CommentRepository에 정의되어 있어야 한다.
<코드>
public interface CommentRepository extends JpaRepository<Comment, Long> {
    List<Comment> findByBoard(Board board);
}

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="1512" alt="스크린샷 2024-09-16 오후 9 25 33" src="https://github.com/user-attachments/assets/78297be2-f4d6-420b-9485-34f2f50ed1ce">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
